### PR TITLE
[BUGFIX] Fixed time remaining units

### DIFF
--- a/tools/timer.h
+++ b/tools/timer.h
@@ -75,7 +75,7 @@ public:
 	 */
 	uint32_t time_remaining() {
 		if (has_expired()) return 0;
-		return ((start_time + duration) - std::chrono::system_clock::now()).count();
+		return std::chrono::duration_cast<std::chrono::milliseconds>((start_time + duration) - std::chrono::system_clock::now()).count();
 	}
 
 	/**

--- a/tools/timer.h
+++ b/tools/timer.h
@@ -31,13 +31,13 @@ namespace orcaSDK
  *	@brief	An object intended to be used as a countdown timer (But does support counting up). Offers a selection of simple operations. 
  */
 class Timer {
-	std::chrono::time_point<std::chrono::system_clock> start_time;
+	std::chrono::time_point<std::chrono::steady_clock> start_time;
 	std::chrono::milliseconds duration{ 0 };
 
 
 public:
 	Timer() {
-		start_time = std::chrono::system_clock::now();
+		start_time = std::chrono::steady_clock::now();
 	}
 
 	/**
@@ -45,7 +45,7 @@ public:
 	 *	@param  _duration - The duration of the timer in milliseconds. 
 	 */
 	void set(uint32_t _duration) {
-		start_time = std::chrono::system_clock::now();
+		start_time = std::chrono::steady_clock::now();
 		duration = std::chrono::milliseconds{ _duration };
 	}
 
@@ -53,7 +53,7 @@ public:
 	 *	@brief		Restarts the timer, but does not modify duration. 
 	 */
 	void reset() {
-		start_time = std::chrono::system_clock::now();
+		start_time = std::chrono::steady_clock::now();
 	}
 
 	/**
@@ -63,7 +63,7 @@ public:
 	 *	@note		bool - If the timer has not yet been set, it is treated as if it has expired. 
 	 */
 	bool has_expired() {
-		return (start_time + duration) <= std::chrono::system_clock::now();
+		return (start_time + duration) <= std::chrono::steady_clock::now();
 	}
 
 	/**
@@ -75,7 +75,7 @@ public:
 	 */
 	uint32_t time_remaining() {
 		if (has_expired()) return 0;
-		return std::chrono::duration_cast<std::chrono::milliseconds>((start_time + duration) - std::chrono::system_clock::now()).count();
+		return std::chrono::duration_cast<std::chrono::milliseconds>((start_time + duration) - std::chrono::steady_clock::now()).count();
 	}
 
 	/**
@@ -87,7 +87,7 @@ public:
 	 */
 	uint32_t time_elapsed() {
 		return std::chrono::duration_cast<std::chrono::milliseconds>(
-			std::chrono::system_clock::now() - start_time
+			std::chrono::steady_clock::now() - start_time
 		).count();
 	}
 };


### PR DESCRIPTION
Timer::time_remaining() was returning remaining time in 10 millionths of a second. Now milliseconds as advertised