### PR TITLE
Changing get_serial_num to return signed int.

### DIFF
--- a/actuator.h
+++ b/actuator.h
@@ -568,9 +568,9 @@ public:
 	/**
 	* @brief Returns the actuator serial number
 	*
-	* @return uint32_t - actuator serial number
+	* @return int32_t - actuator serial number
 	*/
-	OrcaResult<uint32_t> get_serial_number();
+	OrcaResult<int32_t> get_serial_number();
 
 	/**
 	* @brief Return the firmware major version

--- a/src/actuator.cpp
+++ b/src/actuator.cpp
@@ -301,9 +301,9 @@ OrcaResult<uint16_t> Actuator::get_errors() {
 	return read_register_blocking(ERROR_0);
 }
 
-OrcaResult<uint32_t> Actuator::get_serial_number() {
+OrcaResult<int32_t> Actuator::get_serial_number() {
 	OrcaResult<int32_t> result = read_wide_register_blocking(SERIAL_NUMBER_LOW);
-	return { (uint32_t)result.value, result.error };
+	return { result.value, result.error };
 }
 
 OrcaResult<uint16_t> Actuator::get_major_version() {


### PR DESCRIPTION
Currently the only register in the SDK to return an unsigned 32 bit int. Reasons to change:
- I believe -1 better communicates a problem than 4294967295.
- The current serial number scheme should fit within a signed 32 bit int for at least another 200 years, or until we begin selling at least 1000 motors per month.
- It will be consistent with the pattern used for every other wide register.
- It simplifies the python bindings to avoid defining a new type for one function.

Relevant for https://github.com/IrisDynamics/pyorcasdk/issues/28