### PR TITLE
Changing name member variable to std::string to make python binding easier

### DIFF
--- a/actuator.h
+++ b/actuator.h
@@ -94,7 +94,7 @@ public:
 		uint8_t modbus_server_address = 1
 	);
 
-	const char* name;
+	std::string name;
 
 	/**
 	 * @brief	Attempts to open a desired serial port, assigning a baud rate and interframe


### PR DESCRIPTION
When pybind11 passes a python string to a C++ function expecting a char* it seems to create temporary memory that exists for the duration of the function call. It appears the SDK doing a simple copy of that for the constructor causes it to fail in the python bindings. Switching to a std::string to force a deep copy.

See https://github.com/pybind/pybind11/issues/2337 for context around the name binding problem

Resolves issue in pyorcasdk https://github.com/IrisDynamics/pyorcasdk/issues/27