### PR TITLE
Adding serial parameter SerialASIO.h specific function.

### DIFF
--- a/src/SerialASIO.h
+++ b/src/SerialASIO.h
@@ -55,6 +55,17 @@ public:
 		return { 0 };
 	}
 
+	OrcaError update_serial_parameters(unsigned int baud, asio::serial_port::stop_bits::type stop_bits, asio::serial_port::parity::type parity)
+	{
+		if (!serial_port.is_open()) return { 1, "Serial port is not open" };
+
+		serial_port.set_option(asio::serial_port::baud_rate{ baud });
+		serial_port.set_option(asio::serial_port::stop_bits{ stop_bits });
+		serial_port.set_option(asio::serial_port::parity{ parity });
+
+		return { 0 };
+	}
+
 	void close_serial_port() override {
 		serial_port.close();
 	}


### PR DESCRIPTION
Allows us to use non-standard serial parameters when talking to modbus servers. Doesn't update the SerialInterface pure virtual base class, so anyone who makes use of this is following a rather non-standard path of using the Actuator. Currently useful for allowing us to use the SDK as a modbus client for non-ORCA devices.